### PR TITLE
Add charts and dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ This is a simple offline web application for tracking log entries and branch rec
 - Add, edit and delete branches
 - Export logs to an Excel file
 - Import logs from an Excel file
+- Filter logs and paginate results
+- Visual charts for status distribution and logs per branch
+- Optional dark mode toggle
+- Export logs table to PDF
 
 ## Usage
 

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
 <body>
     <header>
         <h1>Offline Log Tracker</h1>
+        <button id="darkToggle" class="nav-btn">Toggle Dark Mode</button>
     </header>
 
     <nav>
@@ -25,9 +26,36 @@
             <h2>Log Records</h2>
             <div class="excel-buttons">
                 <button onclick="exportLogsToExcel()" class="secondary-btn">Download Logs (Excel)</button>
+                <button onclick="exportLogsToPDF()" class="secondary-btn">Download Logs (PDF)</button>
                 <input type="file" id="excelUpload" accept=".xlsx, .xls" onchange="importLogsFromExcel(event)" />
             </div>
+            <div class="filters">
+                <input id="filterBranch" placeholder="Filter by branch" />
+                <select id="filterStatus">
+                    <option value="">All Statuses</option>
+                    <option value="Paused">Paused</option>
+                    <option value="In-Progress">In Progress</option>
+                    <option value="Cancelled">Cancelled</option>
+                    <option value="Completed">Completed</option>
+                    <option value="Hold">Hold</option>
+                </select>
+                <select id="filterChannel">
+                    <option value="">All Channels</option>
+                    <option value="Direct Email - (Personal Inbox)">Direct Email - (Personal Inbox)</option>
+                    <option value="Direct Email (LM- Inbox)">Direct Email (LM- Inbox)</option>
+                    <option value="Comms Portal">Comms Portal</option>
+                </select>
+            </div>
             <div id="output"></div>
+            <div class="pagination">
+                <button id="prevPage" class="secondary-btn">Prev</button>
+                <span id="pageInfo"></span>
+                <button id="nextPage" class="secondary-btn">Next</button>
+            </div>
+            <div class="charts">
+                <canvas id="statusChart" height="200"></canvas>
+                <canvas id="branchChart" height="200"></canvas>
+            </div>
         </section>
 
         <section class="card">
@@ -112,6 +140,9 @@
     </footer>
 
     <script src="https://unpkg.com/dexie@latest/dist/dexie.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
     <script src="script.js"></script>
     <script>
         function showModal(id) {

--- a/style.css
+++ b/style.css
@@ -6,20 +6,23 @@ body {
     color: #333;
 }
 header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
     background-color: #4a90e2;
-    padding: 20px;
-    text-align: center;
+    padding: 15px 20px;
     color: white;
     box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 nav {
     display: flex;
     justify-content: center;
-    gap: 15px;
-    margin: 20px 0;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin: 15px 0;
 }
 .nav-btn {
-    padding: 10px 20px;
+    padding: 8px 16px;
     background-color: #fff;
     border: 2px solid #4a90e2;
     border-radius: 5px;
@@ -78,6 +81,34 @@ form input, form select {
 .secondary-btn:hover {
     background-color: #ddd;
 }
+
+.filters {
+    display: flex;
+    gap: 10px;
+    margin-top: 10px;
+}
+
+.pagination {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+    margin-top: 10px;
+}
+
+.charts {
+    margin-top: 20px;
+}
+
+body.dark {
+    background: #222;
+    color: #eee;
+}
+body.dark header { background-color: #333; }
+body.dark .card { background: #333; color: #eee; }
+body.dark table th { background-color: #444; }
+body.dark table, body.dark th, body.dark td { border-color: #555; }
+body.dark footer { background: #333; color: #eee; }
 table {
     width: 100%;
     border-collapse: collapse;
@@ -132,4 +163,25 @@ footer {
     display: flex;
     gap: 10px;
     margin-bottom: 10px;
+}
+
+@media (max-width: 600px) {
+    header {
+        flex-direction: column;
+        text-align: center;
+    }
+    nav {
+        flex-direction: column;
+    }
+    .filters,
+    .excel-buttons {
+        flex-direction: column;
+    }
+    .card {
+        width: 100%;
+        padding: 15px;
+    }
+    header h1 {
+        font-size: 1.4em;
+    }
 }


### PR DESCRIPTION
## Summary
- add filter, pagination, and chart sections to `index.html`
- add Chart.js, jsPDF, and html2canvas scripts
- implement dark mode, filtering, pagination, chart rendering and PDF export in `script.js`
- style new components and dark mode in `style.css`
- document new features in `README`
- make navigation compact and responsive

## Testing
- `node -c script.js`


------
https://chatgpt.com/codex/tasks/task_e_687e296bb90083269d4a2c54a1fd0cf9