### PR TITLE
Add navigation drawer

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,21 +12,23 @@
 
 <body>
     <header>
+        <button id="menuToggle" class="nav-btn">&#9776;</button>
         <h1>Local Master</h1>
         <button id="darkToggle" class="nav-btn" style="float:right;">Toggle Dark Mode</button>
-
     </header>
 
-    <nav>
-        <button onclick="showModal('logModal')" class="nav-btn">+ Log Entry</button>
-        <button onclick="showModal('branchModal')" class="nav-btn">+ Branch</button>
-    </nav>
-
-    <nav class="section-nav">
-        <button onclick="switchSection('logs')" class="nav-btn">Logs</button>
-        <button onclick="switchSection('branches')" class="nav-btn">Branches</button>
-        <button onclick="switchSection('visual')" class="nav-btn">Visualizations</button>
-    </nav>
+    <aside id="drawer" class="drawer">
+        <button class="nav-btn close-drawer" onclick="closeDrawer()">&times;</button>
+        <nav>
+            <button onclick="showModal('logModal')" class="nav-btn">+ Log Entry</button>
+            <button onclick="showModal('branchModal')" class="nav-btn">+ Branch</button>
+        </nav>
+        <nav class="section-nav">
+            <button onclick="switchSection('logs')" class="nav-btn">Logs</button>
+            <button onclick="switchSection('branches')" class="nav-btn">Branches</button>
+            <button onclick="switchSection('visual')" class="nav-btn">Visualizations</button>
+        </nav>
+    </aside>
 
     <main>
         <section id="logsSection" class="card section">
@@ -157,6 +159,7 @@
     <script src="script.js"></script>
     <script>
         function showModal(id) {
+            if (typeof closeDrawer === 'function') closeDrawer();
             document.getElementById(id).style.display = 'block';
         }
         function closeModal(id) {

--- a/script.js
+++ b/script.js
@@ -16,11 +16,20 @@ let currentPage = 1;
 const itemsPerPage = 10;
 let statusChart, branchChart;
 
+function toggleDrawer() {
+    document.getElementById('drawer').classList.toggle('open');
+}
+
+function closeDrawer() {
+    document.getElementById('drawer').classList.remove('open');
+}
+
 
 function switchSection(name) {
     document.querySelectorAll('.section').forEach(s => s.style.display = 'none');
     const el = document.getElementById(name + 'Section');
     if (el) el.style.display = 'block';
+    closeDrawer();
 }
 function toggleSurveyRating() {
     const show = this.value === "Yes";
@@ -250,6 +259,13 @@ document.addEventListener("DOMContentLoaded", () => {
     document.getElementById('prevPage').addEventListener('click', () => { if (currentPage > 1) { currentPage--; renderTable(); } });
     document.getElementById('nextPage').addEventListener('click', () => { currentPage++; renderTable(); });
     document.getElementById('darkToggle').addEventListener('click', () => { document.body.classList.toggle('dark'); });
+    document.getElementById('menuToggle').addEventListener('click', toggleDrawer);
+    document.addEventListener('click', e => {
+        const drawer = document.getElementById('drawer');
+        if (drawer.classList.contains('open') && !drawer.contains(e.target) && e.target.id !== 'menuToggle') {
+            closeDrawer();
+        }
+    });
     populateBranchList();
     renderTable();
     renderBranchTable();

--- a/style.css
+++ b/style.css
@@ -14,6 +14,54 @@ header {
     color: white;
     box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
+
+#menuToggle {
+    background: none;
+    border: none;
+    color: white;
+    font-size: 1.5em;
+    cursor: pointer;
+    margin-right: 10px;
+}
+
+#menuToggle:hover {
+    color: #ddd;
+}
+
+.drawer {
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 220px;
+    background-color: #4a90e2;
+    padding-top: 60px;
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+    z-index: 9;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.drawer.open {
+    transform: translateX(0);
+}
+
+.drawer .nav-btn {
+    margin: 0 10px;
+    background-color: #fff;
+    border-color: #fff;
+}
+.drawer .nav-btn:hover {
+    background-color: #357ab8;
+    color: #fff;
+}
+
+.close-drawer {
+    align-self: flex-end;
+    margin-right: 10px;
+}
 nav {
     display: flex;
     justify-content: center;
@@ -117,6 +165,8 @@ body.dark .card { background: #333; color: #eee; }
 body.dark table th { background-color: #444; }
 body.dark table, body.dark th, body.dark td { border-color: #555; }
 body.dark footer { background: #333; color: #eee; }
+body.dark .drawer { background-color: #333; }
+body.dark .drawer .nav-btn { color: #333; }
 table {
     width: 100%;
     border-collapse: collapse;


### PR DESCRIPTION
## Summary
- redesign navigation as slide-out drawer
- style drawer and menu button
- support drawer interactions in script
- close drawer when selecting menu items or opening modals
- add close button and ensure modals overlay drawer

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_687e6bb157148326844097687ab0aae8